### PR TITLE
Error between addtext3d and qvtkwidget

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -755,7 +755,10 @@ pcl::visualization::PCLVisualizer::addText3D (
       textActor->SetCamera (renderer->GetActiveCamera ());
 
       renderer->AddActor (textActor);
-      //renderer->Render ();
+      
+      #if VTK_MAJOR_VERSION < 8
+      renderer->Render ();
+      #endif
 
       // Save the pointer/ID pair to the global actor map. If we are saving multiple vtkFollowers
       // for multiple viewport


### PR DESCRIPTION
When using addtext3d to display 3D text in qvtkwidget, an error "access conflict occurs when reading position 0x000000000000008" will be reported. The reason is that "render - > render()" has been used in addtext3d once, but to send 3D text to qvtkwidget window, execute "UI - > qvtkwidget - > setrenderwindow (viewer - > getrenderwindow());Viewer - > setupinteractor (UI - > qvtkwidget - > getinteractor()); ", which is equivalent to repeated rendering, resulting in pointer out of bounds.
To solve this problem it is OK to delete "render - > render()". I have passed the test on vtk8.0.0, Larshg has tested on vtk9.0.1, and vtk6 and 7 have not been tested. Therefore, the judgment statement of VTK version is added.