### PR TITLE
Fix Bug between addText3D and QVTKWidget

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -756,10 +756,7 @@ pcl::visualization::PCLVisualizer::addText3D (
 
       renderer->AddActor (textActor);
       
-      #if VTK_MAJOR_VERSION < 8
-      renderer->Render ();
-      #endif
-
+     
       // Save the pointer/ID pair to the global actor map. If we are saving multiple vtkFollowers
       // for multiple viewport
       const std::string uid = tid + std::string (i, '*');


### PR DESCRIPTION
After successfully testing vtk6,7，just remove “Render->render()” entirely